### PR TITLE
improve bill refresh logging for diagnosability

### DIFF
--- a/apps/mcp-server/src/cache/refresh.ts
+++ b/apps/mcp-server/src/cache/refresh.ts
@@ -109,9 +109,15 @@ export async function warmUpBillsCache(
       continue
     }
 
+    logger.info(
+      { source: 'cache', session, total: allStubIds.length, fresh: freshIds.size, stale: staleIds.length },
+      'bill refresh starting',
+    )
+
     // Fetch stale bills in batches, respecting the wall-time budget
     const fetchedBills: import('@on-record/types').BillDetail[] = []
     let exitedEarly = false
+    let failedCount = 0
 
     for (let i = 0; i < staleIds.length; i += BATCH_SIZE) {
       if (Date.now() - startTime >= wallTimeLimitMs) {
@@ -127,16 +133,18 @@ export async function warmUpBillsCache(
       const settled = await Promise.allSettled(
         batch.map((billId) => provider.getBillDetail(billId, session))
       )
-      for (const result of settled) {
+      batch.forEach((billId, idx) => {
+        const result = settled[idx]
         if (result.status === 'fulfilled') {
           fetchedBills.push(result.value)
         } else {
           logger.error(
-            { source: 'cache', err: result.reason, session },
-            'getBillDetail failed for individual bill — skipping',
+            { source: 'cache', session, billId, err: result.reason },
+            'getBillDetail failed — skipping',
           )
+          failedCount++
         }
-      }
+      })
     }
 
     // Write all fetched bills (even on early exit — no partial batch is silently dropped)
@@ -153,6 +161,18 @@ export async function warmUpBillsCache(
         ...(detail.voteDate !== undefined && { voteDate: detail.voteDate }),
       })))
     }
+
+    logger.info(
+      {
+        source: 'cache',
+        session,
+        fetched: fetchedBills.length,
+        failed: failedCount,
+        remaining: staleIds.length - fetchedBills.length - failedCount,
+        exitedEarly,
+      },
+      'bill refresh complete',
+    )
 
     refreshedSessions.push(session)
 

--- a/apps/mcp-server/src/cache/refresh.ts
+++ b/apps/mcp-server/src/cache/refresh.ts
@@ -133,8 +133,8 @@ export async function warmUpBillsCache(
       const settled = await Promise.allSettled(
         batch.map((billId) => provider.getBillDetail(billId, session))
       )
-      batch.forEach((billId, idx) => {
-        const result = settled[idx]
+      settled.forEach((result, idx) => {
+        const billId = batch[idx]!
         if (result.status === 'fulfilled') {
           fetchedBills.push(result.value)
         } else {

--- a/apps/mcp-server/src/providers/utah-legislature.ts
+++ b/apps/mcp-server/src/providers/utah-legislature.ts
@@ -73,7 +73,7 @@ export class UtahLegislatureProvider implements LegislatureDataProvider {
         try {
           rawJson = JSON.parse(text)
         } catch {
-          throw new Error(`Legislature API returned non-JSON response: ${text}`)
+          throw new Error(`Legislature API returned non-JSON response (HTTP ${res.status}): ${text.slice(0, 200)}`)
         }
         return rawJson
       }, 2, 1000)
@@ -130,12 +130,12 @@ export class UtahLegislatureProvider implements LegislatureDataProvider {
         try {
           rawJson = JSON.parse(text)
         } catch {
-          throw new Error(`Legislature API returned non-JSON response: ${text}`)
+          throw new Error(`Legislature API returned non-JSON response (HTTP ${res.status}): ${text.slice(0, 200)}`)
         }
         return rawJson
       }, 2, 1000)
     } catch (err) {
-      logger.error({ source: 'legislature-api', err }, 'getBillStubsForSession failed after retries')
+      logger.error({ source: 'legislature-api', session, err }, 'getBillStubsForSession failed after retries')
       throw createAppError(
         'legislature-api',
         'Failed to fetch bill stubs for session from Utah Legislature API',
@@ -214,12 +214,12 @@ export class UtahLegislatureProvider implements LegislatureDataProvider {
         try {
           rawJson = JSON.parse(text)
         } catch {
-          throw new Error(`Legislature API returned non-JSON response: ${text}`)
+          throw new Error(`Legislature API returned non-JSON response (HTTP ${res.status}): ${text.slice(0, 200)}`)
         }
         return rawJson
       }, 2, 1000)
     } catch (err) {
-      logger.error({ source: 'legislature-api', err }, 'getBillDetail failed after retries')
+      logger.error({ source: 'legislature-api', billId, session, err }, 'getBillDetail failed after retries')
       throw createAppError(
         'legislature-api',
         `Failed to fetch bill detail for ${billId} from Utah Legislature API`,


### PR DESCRIPTION
## Summary

- Adds `info` logs at the start and end of each session's bill refresh — start log shows `total`/`fresh`/`stale` counts; end log shows `fetched`/`failed`/`remaining`/`exitedEarly`. `remaining > 0` consistently across cron fires is the signal to tune cron cadence.
- Adds `billId` and `session` to per-bill `getBillDetail` error logs so individual failures are identifiable without cross-referencing.
- Truncates non-JSON API responses to 200 chars and includes the HTTP status code, turning opaque maintenance-page floods into legible `HTTP 503` / `HTTP 429` entries.

## Test plan

- [x] All 199 existing tests pass (`pnpm --filter mcp-server test`)
- [x] Lint clean (`pnpm --filter mcp-server lint`)
- [x] Verified live in `wrangler dev --test-scheduled`: `bill refresh starting` and `bill refresh complete` appear with correct field values on `/__scheduled` trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)