### PR TITLE
feat(4.10): store highlightedProvisions as full_text in bills cache

### DIFF
--- a/_bmad-output/implementation-artifacts/4-10-highlighted-provisions-full-text.md
+++ b/_bmad-output/implementation-artifacts/4-10-highlighted-provisions-full-text.md
@@ -1,6 +1,6 @@
 # Story 4.10: Store `highlightedProvisions` as `full_text` in Bills Cache
 
-Status: review
+Status: done
 
 ## Story
 
@@ -85,6 +85,37 @@ so that the model has more context for drafting a substantive, well-grounded con
 - [x] Task 7: Typecheck and test run (AC: 13, 14)
   - [x] `pnpm --filter mcp-server typecheck` — pre-existing errors only (Cloudflare Workers + DOM type conflicts, unrelated to this story)
   - [x] `pnpm --filter mcp-server test` — all 210 tests pass (201 pre-existing + 6 new + 3 already in suite)
+
+### Review Findings
+
+PR 31 review (2026-04-26). Three reviewers: Blind Hunter (adversarial, no context), Edge Case Hunter (boundary analysis with project read), Acceptance Auditor (spec/AC + conventions).
+
+**Initial review** flagged 12 patches, 1 multi-part decision-needed (apparent scope creep: pino logger refactor, AbortController removal, log-level changes), 6 deferred, 5 dismissed as noise.
+
+**After rebase on main** (PR 31 branch was forked before PR 30 landed and was therefore stale on `apps/mcp-server/src/lib/logger.ts`, `apps/mcp-server/src/cache/refresh.ts`, and `apps/mcp-server/src/providers/{types,utah-legislature}.ts`): the apparent scope creep collapsed entirely. The PR now modifies exactly the 10 files declared in the File List. The decision-needed and 5 contingent patches are dropped.
+
+**Net findings:** 6 patches (all fixed), 5 deferred (pre-existing).
+
+**Patches (all applied):**
+
+- [x] [Review][Patch] **CRITICAL — `warmUpBillsCache` does not propagate `fullText` to `writeBills`** [`apps/mcp-server/src/cache/refresh.ts:200-205`] — The provider `getBillsBySession` was updated per AC 9, but it is **not the production refresh path**. `warmUpBillsCache` (the cron-triggered refresh) calls `getBillDetail` per bill and maps `BillDetail` → `Bill` field-by-field, omitting `fullText`. Fixed: added `...(detail.fullText !== undefined && { fullText: detail.fullText }),` after the `voteDate` spread. New regression test in `refresh.test.ts` (`propagates fullText from BillDetail into cached bills row`).
+- [x] [Review][Patch] **Empty-string `fullText` violates absence semantics** [`apps/mcp-server/src/cache/bills.ts`] — Fixed: introduced `normalizeFullText(value)` that returns `null` for `undefined`, empty string, whitespace-only, or pure-tag inputs. Used in the `writeBills` bind. New tests cover empty string and pure-tag/whitespace inputs.
+- [x] [Review][Patch] **`stripHtml` regex destroys non-tag `<`/`>` text and ignores HTML entities** [`apps/mcp-server/src/cache/bills.ts`] — Fixed: tightened tag regex to `/<\/?[a-zA-Z][^>]*>/g` so inequalities like `'A < B and C > D'` survive. Added entity-decoding pass for `&nbsp;`, `&lt;`, `&gt;`, `&quot;`, `&#39;`, `&apos;`, `&amp;` (decoded last to avoid double-decode). New tests cover both behaviors.
+- [x] [Review][Patch] **FTS5-only-on-fullText test does not actually prove `full_text` was the matching column** [`apps/mcp-server/src/cache/bills.test.ts`] — Fixed: existing test now writes a control bill (HB0002) with the same title/summary but no `fullText`, and asserts the search returns only HB0001.
+- [x] [Review][Patch] **`writeBills` FTS5 rebuild has no failure handling** [`apps/mcp-server/src/cache/bills.ts`] — Fixed: wrapped the rebuild call in try/catch; on failure, logs an `error`-level entry noting the index is stale until the next refresh. Bill rows themselves are committed (still useful for non-FTS reads).
+- [x] [Review][Patch] **Migration 002 rebuild can hit D1 per-statement timeout silently** [`apps/mcp-server/migrations/002-add-full-text-to-bills.sql`] — Fixed: added a "POST-DEPLOY VERIFICATION" header note instructing operators to compare `SELECT COUNT(*) FROM bill_fts` vs `SELECT COUNT(*) FROM bills` and re-run rebuild or trigger a refresh if counts differ.
+
+**Deferred (pre-existing or out-of-scope):**
+
+- [x] [Review][Defer] HTML stripping at write time is destructive — originals unrecoverable [`apps/mcp-server/src/cache/bills.ts`] — design choice in story spec; deferred, accepted as-is for MVP.
+- [x] [Review][Defer] `BillDetail` and `Bill` are now structurally indistinguishable when `subjects` is absent [`packages/types/index.ts`] — pre-existing optional discriminator pattern; deferred.
+- [x] [Review][Defer] `wallTimeSeconds` configured to 1 or 2 silently no-ops the entire refresh [`apps/mcp-server/src/cache/refresh.ts`] — pre-existing `(wallTimeSeconds - 2) * 1000` arithmetic; deferred.
+- [x] [Review][Defer] Migration 002 doesn't drop FTS5 triggers if any are added later [`apps/mcp-server/migrations/002-add-full-text-to-bills.sql`] — current schema has no triggers; brittleness is forward-looking; deferred.
+- [x] [Review][Defer] `searchBills` FTS5 path lacks try/catch around `prepare().first()`/`.all()` — invalid FTS5 syntax in a user query becomes a hard 'temporarily unavailable' instead of empty results [`apps/mcp-server/src/cache/bills.ts` FTS5 path] — pre-existing; `searchBillsByTheme` has the guard; this path does not. Mirror that guard. Deferred, pre-existing.
+
+**Rebase note (2026-04-26):** PR 31 branch `claude/e5z-chatgpt-research-emMvr` was rebased onto current `main` (force-update from `4219b13` to a fresh commit on top of `86b0839`). Resulting diff is exactly the 10 declared File List paths.
+
+**Test results after patches:** `pnpm --filter mcp-server test` → 215 passed (210 pre-existing + 5 new). `pnpm --filter mcp-server typecheck` → clean. `pnpm --filter mcp-server lint` → clean.
 
 ## Dev Notes
 
@@ -323,16 +354,19 @@ claude-sonnet-4-6
 - FTS5 table DROP/CREATE/REBUILD pattern works: the content table approach means no bill data is stored in `bill_fts` itself — the rebuild reads from `bills`.
 - `migration/002-add-full-text-to-bills.sql` created for production D1 deployment; `001-initial-schema.sql` and `schema.ts` updated for fresh installs and tests.
 - All 210 tests pass. 6 new tests added: 4 in `bills.test.ts` (fullText round-trip, null handling, HTML stripping, FTS5 search) and 2 in `utah-legislature.test.ts` (fullText propagation present/absent).
+- Post-review patches (2026-04-26): added `normalizeFullText` helper to collapse empty/whitespace/pure-tag inputs to NULL; tightened `stripHtml` regex (`/<\/?[a-zA-Z][^>]*>/g`) so plain-text inequalities survive; added entity-decoding pass; wrapped `bill_fts` rebuild in try/catch so a stale-index failure doesn't reject the whole `writeBills` call. Critical fix: `warmUpBillsCache` (the cron path in `refresh.ts`) now propagates `fullText` from `BillDetail` to the written `Bill` — previous behavior wrote NULL on every refresh, breaking the story's deliverable in production despite all ACs literally passing. Migration 002 header now documents post-deploy verification (count parity check) for D1 timeouts.
 
 ## File List
 
 - `packages/types/index.ts` — added `fullText?: string` to `Bill` interface; removed from `BillDetail` (inherited)
 - `apps/mcp-server/migrations/001-initial-schema.sql` — added `full_text TEXT` to `bills` table; added `full_text` to `bill_fts` FTS5 definition
-- `apps/mcp-server/migrations/002-add-full-text-to-bills.sql` — **new file**: production D1 migration (ALTER TABLE + DROP/CREATE FTS5 + REBUILD)
+- `apps/mcp-server/migrations/002-add-full-text-to-bills.sql` — **new file**: production D1 migration (ALTER TABLE + DROP/CREATE FTS5 + REBUILD); post-review: header documents post-deploy count-parity verification
 - `apps/mcp-server/src/cache/schema.ts` — updated `SCHEMA_SQL` identically to `001-initial-schema.sql`
-- `apps/mcp-server/src/cache/bills.ts` — added `full_text` to `BillRow`; added `stripHtml()` helper; updated `rowToBill()`, `getBillsBySponsor()`, `getBillsBySession()`, `searchBillsByTheme()`, `searchBills()` (both paths), `writeBills()`
+- `apps/mcp-server/src/cache/bills.ts` — added `full_text` to `BillRow`; added `stripHtml()` helper; updated `rowToBill()`, `getBillsBySponsor()`, `getBillsBySession()`, `searchBillsByTheme()`, `searchBills()` (both paths), `writeBills()`. Post-review: tightened `stripHtml` regex + added entity-decoding pass; introduced `normalizeFullText` helper (used in `writeBills` bind); imported `logger` and wrapped `bill_fts` rebuild in try/catch
 - `apps/mcp-server/src/providers/utah-legislature.ts` — added `fullText` propagation in `getBillsBySession()`
-- `apps/mcp-server/src/cache/bills.test.ts` — added `describe('fullText storage and retrieval', ...)` with 4 tests
+- `apps/mcp-server/src/cache/refresh.ts` — **post-review (CRITICAL fix):** added `fullText` spread in the `BillDetail` → `Bill` mapping inside `warmUpBillsCache`, so the cron refresh actually persists the new field
+- `apps/mcp-server/src/cache/bills.test.ts` — added `describe('fullText storage and retrieval', ...)` with 4 tests; post-review: FTS5 test gained a control bill; added tests for non-tag angle-bracket preservation, entity decoding, empty-string input, and pure-tag/whitespace input
+- `apps/mcp-server/src/cache/refresh.test.ts` — **post-review:** new test asserts `warmUpBillsCache` writes `full_text` to the `bills` row when `BillDetail.fullText` is provided
 - `apps/mcp-server/src/providers/utah-legislature.test.ts` — added 2 fullText propagation tests to `getBillsBySession` block
 - `_bmad-output/implementation-artifacts/4-10-highlighted-provisions-full-text.md` (this file — story tracking)
 - `_bmad-output/implementation-artifacts/sprint-status.yaml` (modified — story status)
@@ -341,3 +375,5 @@ claude-sonnet-4-6
 
 - 2026-04-26: Story created from E5-z entry in ChatGPT Apps research (technical-chatgpt-apps-on-record-research-2026-04-18.md). E5-z-spike incorporated inline: format is plain text per existing test mock at utah-legislature.test.ts:49; HTML stripping applied defensively.
 - 2026-04-26: Implementation complete. All 210 tests pass. Story status set to review.
+- 2026-04-26: Branch rebased on main (PR 30 had landed with logger / AbortController refactors that were stale on this branch). Apparent scope creep in initial review collapsed.
+- 2026-04-26: Code review complete. 6 patches applied (CRITICAL `warmUpBillsCache` fullText propagation + 5 others), 5 deferred items recorded. 215 tests pass. Story status set to done.

--- a/_bmad-output/implementation-artifacts/4-10-highlighted-provisions-full-text.md
+++ b/_bmad-output/implementation-artifacts/4-10-highlighted-provisions-full-text.md
@@ -12,9 +12,9 @@ so that the model has more context for drafting a substantive, well-grounded con
 
 1. **`Bill` interface updated**: `packages/types/index.ts` has `fullText?: string` added to the `Bill` interface (after `billUrl?`). It is removed from `BillDetail` (since `BillDetail extends Bill`, it inherits the field).
 
-2. **`full_text` column added to `bills` table**: `migrations/001-initial-schema.sql` and `src/cache/schema.ts` `SCHEMA_SQL` both declare `full_text TEXT` as an optional column in the `bills` table.
+2. **`full_text` column added to `bills` table**: `src/cache/schema.ts` `SCHEMA_SQL` (the cumulative schema used by tests/local Node.js paths) declares `full_text TEXT` as an optional column in the `bills` table. `migrations/001-initial-schema.sql` is **not** modified — migrations are append-only.
 
-3. **`full_text` added to `bill_fts` virtual table**: `bill_fts` FTS5 virtual table includes `full_text` as a third indexed column (after `title` and `summary`).
+3. **`full_text` added to `bill_fts` virtual table**: In `src/cache/schema.ts`, the `bill_fts` FTS5 virtual table includes `full_text` as a third indexed column (after `title` and `summary`). The production schema gets the same shape via migration 002 (DROP + CREATE).
 
 4. **Production D1 migration file created**: `migrations/002-add-full-text-to-bills.sql` adds the `full_text` column to the existing `bills` table, drops and recreates `bill_fts` with `full_text`, and rebuilds the FTS5 index.
 
@@ -51,10 +51,10 @@ so that the model has more context for drafting a substantive, well-grounded con
   - [x] Remove `fullText?: string` from `BillDetail` (it inherits from `Bill` via `extends`)
   - [x] Leave all other fields and interfaces unchanged
 
-- [x] Task 2: Update schema files with `full_text` column and FTS5 (AC: 2, 3, 4)
-  - [x] In `apps/mcp-server/migrations/001-initial-schema.sql`, add `full_text TEXT` after `vote_date TEXT` in the `bills` table; add `full_text` to `bill_fts` FTS5 definition after `summary`
-  - [x] In `apps/mcp-server/src/cache/schema.ts` (`SCHEMA_SQL`), make identical changes
-  - [x] Create `apps/mcp-server/migrations/002-add-full-text-to-bills.sql` with: `ALTER TABLE bills ADD COLUMN full_text TEXT;`, DROP + CREATE `bill_fts` with `full_text`, REBUILD
+- [x] Task 2: Update schema artifacts (AC: 2, 3, 4)
+  - [x] In `apps/mcp-server/src/cache/schema.ts` (`SCHEMA_SQL`), add `full_text TEXT` to `bills` after `vote_date`; add `full_text` to `bill_fts` after `summary`. This is the cumulative schema used by tests and local Node.js paths.
+  - [x] Do **not** modify `apps/mcp-server/migrations/001-initial-schema.sql` — migrations are append-only. Modifying 001 is dead-code for already-applied DBs and conflicts with 002 on fresh installs (SQLite has no `ADD COLUMN IF NOT EXISTS`).
+  - [x] Create `apps/mcp-server/migrations/002-add-full-text-to-bills.sql` with: `ALTER TABLE bills ADD COLUMN full_text TEXT;`, DROP + CREATE `bill_fts` with `full_text`, REBUILD. Applies to both fresh installs and existing prod D1.
 
 - [x] Task 3: Update `bills.ts` — BillRow, rowToBill, writeBills, SELECT queries (AC: 5, 6, 7, 8)
   - [x] Add `full_text: string | null` to `BillRow` interface
@@ -134,16 +134,18 @@ highlightedProvisions: 'This bill amends weighted pupil unit provisions...',
 
 The existing test mock (and the `getBillDetail` test at line 516 that verifies `fullText: 'This bill amends weighted pupil unit provisions...'`) confirms the format is plain text. However, the official API docs do not specify format, so HTML stripping is applied as a defensive measure — it is a no-op for plain text.
 
-### CRITICAL: Schema Migration Strategy
+### Schema Migration Strategy
 
-**Two schema files must be kept in sync:**
-- `migrations/001-initial-schema.sql` — for fresh installs (new environments)
-- `src/cache/schema.ts` (`SCHEMA_SQL`) — for tests and local Node.js dev
+**Migrations are append-only.** `migrations/001-initial-schema.sql` is **not** modified for this story:
+- D1 databases that already applied 001 won't re-run it, so editing 001 has no effect on existing prod.
+- A fresh D1 environment runs 001 *and* 002 in order. If 001 is edited to include `full_text`, then 002's `ALTER TABLE bills ADD COLUMN full_text TEXT` fails (SQLite has no `ADD COLUMN IF NOT EXISTS`). Edited-001 + 002 is a broken combination for fresh installs.
 
-**The production migration file:**
-- `migrations/002-add-full-text-to-bills.sql` — for existing D1 databases
+**File responsibilities:**
+- `migrations/001-initial-schema.sql` — the original create statements (unchanged in this story).
+- `migrations/002-add-full-text-to-bills.sql` — the additive migration: `ALTER TABLE bills ADD COLUMN full_text TEXT`, then DROP/CREATE `bill_fts` with the new third column, then `INSERT INTO bill_fts(bill_fts) VALUES('rebuild')`. Runs on both fresh installs and existing prod.
+- `src/cache/schema.ts` (`SCHEMA_SQL`) — cumulative current-state schema used by tests and local Node.js dev (not by the migration runner). Updated to reflect what a database looks like after all migrations apply.
 
-The FTS5 virtual table CANNOT be altered. To add `full_text` to FTS5:
+The FTS5 virtual table CANNOT be altered. To add `full_text` to FTS5 in 002:
 1. `DROP TABLE IF EXISTS bill_fts`
 2. `CREATE VIRTUAL TABLE bill_fts USING fts5(title, summary, full_text, content='bills', content_rowid='rowid')`
 3. `INSERT INTO bill_fts(bill_fts) VALUES('rebuild')`
@@ -359,7 +361,7 @@ claude-sonnet-4-6
 ## File List
 
 - `packages/types/index.ts` — added `fullText?: string` to `Bill` interface; removed from `BillDetail` (inherited)
-- `apps/mcp-server/migrations/001-initial-schema.sql` — added `full_text TEXT` to `bills` table; added `full_text` to `bill_fts` FTS5 definition
+- `apps/mcp-server/migrations/001-initial-schema.sql` — **unchanged** (migrations are append-only; previously edited in error, reverted post-review)
 - `apps/mcp-server/migrations/002-add-full-text-to-bills.sql` — **new file**: production D1 migration (ALTER TABLE + DROP/CREATE FTS5 + REBUILD); post-review: header documents post-deploy count-parity verification
 - `apps/mcp-server/src/cache/schema.ts` — updated `SCHEMA_SQL` identically to `001-initial-schema.sql`
 - `apps/mcp-server/src/cache/bills.ts` — added `full_text` to `BillRow`; added `stripHtml()` helper; updated `rowToBill()`, `getBillsBySponsor()`, `getBillsBySession()`, `searchBillsByTheme()`, `searchBills()` (both paths), `writeBills()`. Post-review: tightened `stripHtml` regex + added entity-decoding pass; introduced `normalizeFullText` helper (used in `writeBills` bind); imported `logger` and wrapped `bill_fts` rebuild in try/catch
@@ -377,3 +379,4 @@ claude-sonnet-4-6
 - 2026-04-26: Implementation complete. All 210 tests pass. Story status set to review.
 - 2026-04-26: Branch rebased on main (PR 30 had landed with logger / AbortController refactors that were stale on this branch). Apparent scope creep in initial review collapsed.
 - 2026-04-26: Code review complete. 6 patches applied (CRITICAL `warmUpBillsCache` fullText propagation + 5 others), 5 deferred items recorded. 215 tests pass. Story status set to done.
+- 2026-04-26: Reverted incorrect edit to `migrations/001-initial-schema.sql` — migrations are append-only and editing 001 broke the fresh-install path (001's `full_text` plus 002's `ALTER TABLE` is incompatible because SQLite lacks `ADD COLUMN IF NOT EXISTS`). AC 2/3 and Task 2 reworded so the cumulative schema lives only in `src/cache/schema.ts` and `migrations/002`. Existing prod D1 was already on the correct path (002 supplies the column).

--- a/_bmad-output/implementation-artifacts/4-10-highlighted-provisions-full-text.md
+++ b/_bmad-output/implementation-artifacts/4-10-highlighted-provisions-full-text.md
@@ -1,0 +1,343 @@
+# Story 4.10: Store `highlightedProvisions` as `full_text` in Bills Cache
+
+Status: review
+
+## Story
+
+As a **constituent using the ChatGPT App**,
+I want bill search results to include richer legislative text beyond the one-paragraph summary,
+so that the model has more context for drafting a substantive, well-grounded constituent letter.
+
+## Acceptance Criteria
+
+1. **`Bill` interface updated**: `packages/types/index.ts` has `fullText?: string` added to the `Bill` interface (after `billUrl?`). It is removed from `BillDetail` (since `BillDetail extends Bill`, it inherits the field).
+
+2. **`full_text` column added to `bills` table**: `migrations/001-initial-schema.sql` and `src/cache/schema.ts` `SCHEMA_SQL` both declare `full_text TEXT` as an optional column in the `bills` table.
+
+3. **`full_text` added to `bill_fts` virtual table**: `bill_fts` FTS5 virtual table includes `full_text` as a third indexed column (after `title` and `summary`).
+
+4. **Production D1 migration file created**: `migrations/002-add-full-text-to-bills.sql` adds the `full_text` column to the existing `bills` table, drops and recreates `bill_fts` with `full_text`, and rebuilds the FTS5 index.
+
+5. **HTML stripping applied at write time**: A `stripHtml(s: string): string` helper in `bills.ts` strips HTML tags (regex-based) before storing `full_text`. The helper is applied in `writeBills()` when `bill.fullText` is defined.
+
+6. **`rowToBill` maps `full_text` to `fullText`**: `rowToBill()` maps a non-null `full_text` DB column to `bill.fullText`. A null value maps to `undefined` (not `null`), matching `exactOptionalPropertyTypes: true`.
+
+7. **`writeBills` stores `fullText`**: The INSERT in `writeBills()` includes `full_text` and binds `bill.fullText !== undefined ? stripHtml(bill.fullText) : null`.
+
+8. **All SELECT queries updated**: All SQL SELECT statements in `bills.ts` (in `getBillsBySponsor`, `getBillsBySession`, `searchBillsByTheme`, `searchBills` both paths) include `full_text` in the column list.
+
+9. **`getBillsBySession` passes `fullText` through**: In `utah-legislature.ts`, `getBillsBySession()` spreads `fullText` from `BillDetail` into the `Bill` object when `detail.fullText !== undefined`, using `...(detail.fullText !== undefined && { fullText: detail.fullText })`.
+
+10. **`bills.test.ts` verifies `fullText` round-trip**: Tests confirm:
+    - Writing a bill with `fullText: 'Amends Section 53G-7-218...'` and reading back returns `fullText === 'Amends Section 53G-7-218...'`
+    - Writing a bill without `fullText` returns `fullText === undefined` (not null)
+    - Writing a bill with HTML in `fullText` (e.g., `'<b>Amends</b> Section 53G-7-218'`) strips tags and stores `'Amends Section 53G-7-218'`
+    - FTS5 query matching on `full_text` content works (query for text only in `fullText`, not in `title`/`summary`)
+
+11. **`utah-legislature.test.ts` verifies `fullText` propagation**: Tests confirm:
+    - `getBillsBySession()` includes `fullText` on the returned `Bill` when the API provides `highlightedProvisions`
+    - `getBillsBySession()` omits `fullText` (property absent, not undefined assignment) when the API does not provide `highlightedProvisions`
+
+12. **Key phrase for error-path tests**: N/A — no new error paths introduced.
+
+13. `pnpm --filter mcp-server typecheck` passes with zero errors.
+
+14. `pnpm --filter mcp-server test` passes — all existing tests continue to pass without modification.
+
+## Tasks / Subtasks
+
+- [x] Task 1: Update `Bill` interface and `BillDetail` in types (AC: 1, 13)
+  - [x] In `packages/types/index.ts`, add `fullText?: string` to `Bill` interface after `billUrl?: string`
+  - [x] Remove `fullText?: string` from `BillDetail` (it inherits from `Bill` via `extends`)
+  - [x] Leave all other fields and interfaces unchanged
+
+- [x] Task 2: Update schema files with `full_text` column and FTS5 (AC: 2, 3, 4)
+  - [x] In `apps/mcp-server/migrations/001-initial-schema.sql`, add `full_text TEXT` after `vote_date TEXT` in the `bills` table; add `full_text` to `bill_fts` FTS5 definition after `summary`
+  - [x] In `apps/mcp-server/src/cache/schema.ts` (`SCHEMA_SQL`), make identical changes
+  - [x] Create `apps/mcp-server/migrations/002-add-full-text-to-bills.sql` with: `ALTER TABLE bills ADD COLUMN full_text TEXT;`, DROP + CREATE `bill_fts` with `full_text`, REBUILD
+
+- [x] Task 3: Update `bills.ts` — BillRow, rowToBill, writeBills, SELECT queries (AC: 5, 6, 7, 8)
+  - [x] Add `full_text: string | null` to `BillRow` interface
+  - [x] Add `stripHtml(s: string): string` helper function (module-private, not exported)
+  - [x] In `rowToBill()`, add: `if (row.full_text !== null) bill.fullText = row.full_text`
+  - [x] In `getBillsBySponsor()` SELECT, add `full_text` to the column list
+  - [x] In `getBillsBySession()` SELECT, add `full_text` to the column list
+  - [x] In `searchBillsByTheme()` SELECT, add `full_text` to the column list
+  - [x] In `searchBills()` FTS5 path SELECT (pageSql), add `b.full_text` to the column list
+  - [x] In `searchBills()` direct path SELECT (pageSql), add `full_text` to the column list
+  - [x] In `writeBills()` INSERT, add `full_text` to column list and bind `bill.fullText !== undefined ? stripHtml(bill.fullText) : null`
+
+- [x] Task 4: Update `utah-legislature.ts` — pass `fullText` through `getBillsBySession` (AC: 9)
+  - [x] In `getBillsBySession()`, inside the `Promise.allSettled` loop where each `Bill` is constructed, add: `...(detail.fullText !== undefined && { fullText: detail.fullText })`
+
+- [x] Task 5: Add tests — `bills.test.ts` (AC: 10, 14)
+  - [x] Add `describe('fullText storage and retrieval', ...)` block with:
+    - Test: write bill with `fullText`, read back via `getBillsBySponsor`, assert `fullText` matches stored value
+    - Test: write bill without `fullText`, read back, assert `fullText === undefined`
+    - Test: write bill with HTML in `fullText` (e.g., `'<b>Amends</b> Section 53G'`), read back, assert stripped (`'Amends Section 53G'`)
+    - Test: FTS5 `searchBills({ query: 'uniqueprovision' })` returns the bill when `uniqueprovision` is only in `fullText` (not in title or summary)
+
+- [x] Task 6: Add tests — `utah-legislature.test.ts` (AC: 11, 14)
+  - [x] Add tests within existing `describe('getBillsBySession', ...)` block:
+    - Test: `getBillsBySession` includes `fullText` on the Bill when API provides `highlightedProvisions`
+    - Test: `getBillsBySession` omits `fullText` (property absent) when API lacks `highlightedProvisions`
+
+- [x] Task 7: Typecheck and test run (AC: 13, 14)
+  - [x] `pnpm --filter mcp-server typecheck` — pre-existing errors only (Cloudflare Workers + DOM type conflicts, unrelated to this story)
+  - [x] `pnpm --filter mcp-server test` — all 210 tests pass (201 pre-existing + 6 new + 3 already in suite)
+
+## Dev Notes
+
+### What This Story Is
+
+This is the "E5-z / Tier 1 No-Widget Improvement" from the 2026-04-18 ChatGPT Apps technical research (`_bmad-output/planning-artifacts/research/technical-chatgpt-apps-on-record-research-2026-04-18.md`, section "Track 2: Store and Surface `highlightedProvisions` as `fullText`").
+
+The previous stories (4.8 = E5-x, 4.9 = E5-y) encoded behavioral preconditions into tool descriptions and added `billUrl`. This story wires through the `highlightedProvisions` field that is already fetched on every cache refresh but currently discarded. Storing it gives the model richer per-bill context and improves FTS5 keyword search quality.
+
+### E5-z-spike Findings
+
+Spike was done by examining the existing `utah-legislature.test.ts` mock at line 49:
+```typescript
+highlightedProvisions: 'This bill amends weighted pupil unit provisions...',
+```
+
+The existing test mock (and the `getBillDetail` test at line 516 that verifies `fullText: 'This bill amends weighted pupil unit provisions...'`) confirms the format is plain text. However, the official API docs do not specify format, so HTML stripping is applied as a defensive measure — it is a no-op for plain text.
+
+### CRITICAL: Schema Migration Strategy
+
+**Two schema files must be kept in sync:**
+- `migrations/001-initial-schema.sql` — for fresh installs (new environments)
+- `src/cache/schema.ts` (`SCHEMA_SQL`) — for tests and local Node.js dev
+
+**The production migration file:**
+- `migrations/002-add-full-text-to-bills.sql` — for existing D1 databases
+
+The FTS5 virtual table CANNOT be altered. To add `full_text` to FTS5:
+1. `DROP TABLE IF EXISTS bill_fts`
+2. `CREATE VIRTUAL TABLE bill_fts USING fts5(title, summary, full_text, content='bills', content_rowid='rowid')`
+3. `INSERT INTO bill_fts(bill_fts) VALUES('rebuild')`
+
+This is safe because FTS5 with `content='bills'` stores no data itself — it's an index over `bills`. Dropping and rebuilding does not lose data.
+
+### HTML Stripping Helper
+
+```typescript
+// Module-private — applied in writeBills() before storing full_text
+function stripHtml(s: string): string {
+  return s.replace(/<[^>]+>/g, ' ').replace(/\s{2,}/g, ' ').trim()
+}
+```
+
+Apply only when `bill.fullText !== undefined`:
+```typescript
+bill.fullText !== undefined ? stripHtml(bill.fullText) : null
+```
+
+### `BillRow` Update
+
+Add `full_text: string | null` after `vote_date`:
+```typescript
+interface BillRow {
+  id: string
+  session: string
+  title: string
+  summary: string
+  status: string
+  sponsor_id: string
+  floor_sponsor_id: string | null
+  vote_result: string | null
+  vote_date: string | null
+  full_text: string | null  // NEW
+}
+```
+
+### `rowToBill` Update
+
+After the existing `vote_date` null-check block:
+```typescript
+if (row.full_text !== null) {
+  bill.fullText = row.full_text
+}
+```
+
+### SELECT Query Updates
+
+All four read paths in `bills.ts` need `full_text` added:
+
+`getBillsBySponsor`: Change `SELECT id, session, title, summary, status, sponsor_id, floor_sponsor_id, vote_result, vote_date FROM bills WHERE sponsor_id = ?`
+→ add `full_text` after `vote_date`
+
+`getBillsBySession`: Same pattern.
+
+`searchBillsByTheme`: Same pattern (FTS5 JOIN path).
+
+`searchBills` FTS5 path (pageSql): Change `SELECT b.id, b.session, b.title, b.summary, b.status, b.sponsor_id, b.floor_sponsor_id, b.vote_result, b.vote_date`
+→ add `b.full_text` after `b.vote_date`
+
+`searchBills` direct path (pageSql): Change `SELECT id, session, title, summary, status, sponsor_id, floor_sponsor_id, vote_result, vote_date`
+→ add `full_text` after `vote_date`
+
+### `writeBills` UPDATE
+
+INSERT column list: add `full_text` after `vote_date`
+INSERT values: add `?` for `full_text` after `vote_date` bind
+Bind: add `bill.fullText !== undefined ? stripHtml(bill.fullText) : null` after the `voteDate` bind
+
+```typescript
+`INSERT OR REPLACE INTO bills
+  (id, session, title, summary, status, sponsor_id, floor_sponsor_id, vote_result, vote_date, full_text, cached_at)
+ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+```
+
+### `getBillsBySession` Update (utah-legislature.ts)
+
+Current code (lines 181-192):
+```typescript
+bills.push({
+  id: detail.id,
+  session: detail.session,
+  title: detail.title,
+  summary: detail.summary,
+  status: detail.status,
+  sponsorId: detail.sponsorId,
+  ...(detail.floorSponsorId !== undefined && { floorSponsorId: detail.floorSponsorId }),
+  ...(detail.voteResult !== undefined && { voteResult: detail.voteResult }),
+  ...(detail.voteDate !== undefined && { voteDate: detail.voteDate }),
+})
+```
+
+Add one line after `voteDate`:
+```typescript
+...(detail.fullText !== undefined && { fullText: detail.fullText }),
+```
+
+### Why `search-bills.ts` Needs No Change
+
+The tool returns `JSON.stringify(result)` where `result.bills` is `Bill[]`. Once `rowToBill` includes `fullText`, it flows through automatically. No change to `search-bills.ts`.
+
+### FTS5 Search Impact
+
+Adding `full_text` to `bill_fts` means `searchBills({ query: 'property tax' })` now matches against the `highlightedProvisions` text in addition to `title` and `summary`. This improves keyword search quality — a bill that mentions "property tax" in its specific statutory change description (but not in the one-paragraph summary) will now surface.
+
+### Testing Approach
+
+**`bills.test.ts` — add within the existing `describe('bills cache', ...)` block:**
+
+```typescript
+describe('fullText storage and retrieval', () => {
+  it('stores and returns fullText when bill has fullText', async () => {
+    await writeBills(env.DB, [makeBill({ fullText: 'Amends Section 53G-7-218 to require...' })])
+    const result = await getBillsBySponsor(env.DB, 'leg-001')
+    expect(result[0]?.fullText).toBe('Amends Section 53G-7-218 to require...')
+  })
+
+  it('returns fullText as undefined when bill has no fullText', async () => {
+    await writeBills(env.DB, [makeBill()])
+    const result = await getBillsBySponsor(env.DB, 'leg-001')
+    expect(result[0]?.fullText).toBeUndefined()
+  })
+
+  it('strips HTML tags from fullText before storing', async () => {
+    await writeBills(env.DB, [makeBill({ fullText: '<b>Amends</b> Section 53G-7-218' })])
+    const result = await getBillsBySponsor(env.DB, 'leg-001')
+    expect(result[0]?.fullText).toBe('Amends Section 53G-7-218')
+  })
+
+  it('FTS5 query matches content only in fullText — bill surfaces in search results', async () => {
+    await writeBills(env.DB, [makeBill({
+      title: 'School Funding Act',
+      summary: 'General school funding amendments',
+      fullText: 'uniqueprovisionterm that appears nowhere else',
+    })])
+    const result = await searchBills(env.DB, { query: 'uniqueprovisionterm' })
+    expect(result.total).toBe(1)
+    expect(result.bills[0]?.id).toBe('HB0001')
+  })
+})
+```
+
+**`utah-legislature.test.ts` — add within the existing `describe('getBillsBySession', ...)` block:**
+
+```typescript
+it('includes fullText on returned Bill when API provides highlightedProvisions', async () => {
+  fetchMock
+    .mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify([{ number: 'HB0001', trackingID: 'TUBFCRPIYI' }]) })
+    .mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify(mockBillDetailResponse) })
+
+  const promise = provider.getBillsBySession('2026GS')
+  await vi.runAllTimersAsync()
+  const result = await promise
+
+  expect(result).toHaveLength(1)
+  expect(result[0]?.fullText).toBe('This bill amends weighted pupil unit provisions...')
+})
+
+it('omits fullText (property absent) when API lacks highlightedProvisions', async () => {
+  fetchMock
+    .mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify([{ number: 'HB0002', trackingID: 'BKSTYLLAEC' }]) })
+    .mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify(mockBillDetail2Response) })
+
+  const promise = provider.getBillsBySession('2026GS')
+  await vi.runAllTimersAsync()
+  const result = await promise
+
+  expect(result).toHaveLength(1)
+  expect('fullText' in (result[0] ?? {})).toBe(false)
+})
+```
+
+### Key Architectural Rules
+
+- `console.log` FORBIDDEN in `apps/mcp-server/` — not relevant to this change
+- `better-sqlite3` imports confined to `apps/mcp-server/src/cache/` — not applicable (using D1)
+- All shared types in `packages/types/` only — `Bill` interface lives there correctly
+- `exactOptionalPropertyTypes: true` — null in DB must become `undefined` (not null) in returned `Bill`
+
+### References
+
+- Research source: [`_bmad-output/planning-artifacts/research/technical-chatgpt-apps-on-record-research-2026-04-18.md`] — Track 2: Store and Surface `highlightedProvisions`, E5-z story entry in Implementation Sequencing table
+- Previous story (4.9): [`_bmad-output/implementation-artifacts/4-9-bill-url-computed-field.md`]
+- `Bill` interface: [`packages/types/index.ts` lines 20–32]
+- `BillDetail` interface: [`packages/types/index.ts` lines 34–39]
+- `BillRow` and `rowToBill`: [`apps/mcp-server/src/cache/bills.ts` lines 9–42]
+- `writeBills`: [`apps/mcp-server/src/cache/bills.ts` lines 285–318]
+- `getBillsBySession` (provider): [`apps/mcp-server/src/providers/utah-legislature.ts` lines 159–202]
+- Current schema: [`apps/mcp-server/migrations/001-initial-schema.sql`]
+- `SCHEMA_SQL`: [`apps/mcp-server/src/cache/schema.ts`]
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-sonnet-4-6
+
+### Debug Log References
+
+(none yet)
+
+### Completion Notes List
+
+- `fullText` flows automatically into `search_bills` tool responses via `rowToBill()` — no changes needed to `search-bills.ts` or its tests.
+- HTML stripping is applied in `writeBills()` before storing to D1; uses regex-based `stripHtml()` helper (no external library needed in Workers).
+- E5-z-spike findings: `highlightedProvisions` is plain text per existing test mock at `utah-legislature.test.ts:49` and the `getBillDetail` test at line 516. HTML stripping is applied defensively since API docs don't specify format.
+- FTS5 table DROP/CREATE/REBUILD pattern works: the content table approach means no bill data is stored in `bill_fts` itself — the rebuild reads from `bills`.
+- `migration/002-add-full-text-to-bills.sql` created for production D1 deployment; `001-initial-schema.sql` and `schema.ts` updated for fresh installs and tests.
+- All 210 tests pass. 6 new tests added: 4 in `bills.test.ts` (fullText round-trip, null handling, HTML stripping, FTS5 search) and 2 in `utah-legislature.test.ts` (fullText propagation present/absent).
+
+## File List
+
+- `packages/types/index.ts` — added `fullText?: string` to `Bill` interface; removed from `BillDetail` (inherited)
+- `apps/mcp-server/migrations/001-initial-schema.sql` — added `full_text TEXT` to `bills` table; added `full_text` to `bill_fts` FTS5 definition
+- `apps/mcp-server/migrations/002-add-full-text-to-bills.sql` — **new file**: production D1 migration (ALTER TABLE + DROP/CREATE FTS5 + REBUILD)
+- `apps/mcp-server/src/cache/schema.ts` — updated `SCHEMA_SQL` identically to `001-initial-schema.sql`
+- `apps/mcp-server/src/cache/bills.ts` — added `full_text` to `BillRow`; added `stripHtml()` helper; updated `rowToBill()`, `getBillsBySponsor()`, `getBillsBySession()`, `searchBillsByTheme()`, `searchBills()` (both paths), `writeBills()`
+- `apps/mcp-server/src/providers/utah-legislature.ts` — added `fullText` propagation in `getBillsBySession()`
+- `apps/mcp-server/src/cache/bills.test.ts` — added `describe('fullText storage and retrieval', ...)` with 4 tests
+- `apps/mcp-server/src/providers/utah-legislature.test.ts` — added 2 fullText propagation tests to `getBillsBySession` block
+- `_bmad-output/implementation-artifacts/4-10-highlighted-provisions-full-text.md` (this file — story tracking)
+- `_bmad-output/implementation-artifacts/sprint-status.yaml` (modified — story status)
+
+## Change Log
+
+- 2026-04-26: Story created from E5-z entry in ChatGPT Apps research (technical-chatgpt-apps-on-record-research-2026-04-18.md). E5-z-spike incorporated inline: format is plain text per existing test mock at utah-legislature.test.ts:49; HTML stripping applied defensively.
+- 2026-04-26: Implementation complete. All 210 tests pass. Story status set to review.

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -111,6 +111,7 @@ development_status:
   # so conversation flow holds in ChatGPT Apps context (no system prompt available)
   4-8-mcp-tool-description-chatgpt-apps-behavioral-encoding: done
   4-9-bill-url-computed-field: done
+  4-10-highlighted-provisions-full-text: review
   4-x-chatgpt-app-configuration-and-publishing: backlog
   epic-4-retrospective: optional
 

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -111,7 +111,7 @@ development_status:
   # so conversation flow holds in ChatGPT Apps context (no system prompt available)
   4-8-mcp-tool-description-chatgpt-apps-behavioral-encoding: done
   4-9-bill-url-computed-field: done
-  4-10-highlighted-provisions-full-text: review
+  4-10-highlighted-provisions-full-text: done
   4-x-chatgpt-app-configuration-and-publishing: backlog
   epic-4-retrospective: optional
 

--- a/apps/mcp-server/migrations/001-initial-schema.sql
+++ b/apps/mcp-server/migrations/001-initial-schema.sql
@@ -24,7 +24,6 @@ CREATE TABLE IF NOT EXISTS bills (
   floor_sponsor_id TEXT,
   vote_result      TEXT,
   vote_date        TEXT,
-  full_text        TEXT,
   cached_at        TEXT    NOT NULL,
   PRIMARY KEY (id, session)
 );
@@ -33,7 +32,6 @@ CREATE VIRTUAL TABLE IF NOT EXISTS bill_fts
 USING fts5(
   title,
   summary,
-  full_text,
   content='bills',
   content_rowid='rowid'
 );

--- a/apps/mcp-server/migrations/001-initial-schema.sql
+++ b/apps/mcp-server/migrations/001-initial-schema.sql
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS bills (
   floor_sponsor_id TEXT,
   vote_result      TEXT,
   vote_date        TEXT,
+  full_text        TEXT,
   cached_at        TEXT    NOT NULL,
   PRIMARY KEY (id, session)
 );
@@ -32,6 +33,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS bill_fts
 USING fts5(
   title,
   summary,
+  full_text,
   content='bills',
   content_rowid='rowid'
 );

--- a/apps/mcp-server/migrations/002-add-full-text-to-bills.sql
+++ b/apps/mcp-server/migrations/002-add-full-text-to-bills.sql
@@ -1,0 +1,24 @@
+-- migrations/002-add-full-text-to-bills.sql
+-- Adds full_text column (highlightedProvisions from Utah Legislature API) to bills table.
+-- Recreates bill_fts FTS5 virtual table to include full_text as a third indexed column.
+--
+-- Applied via: wrangler d1 migrations apply on-record-cache [--local]
+--
+-- FTS5 virtual tables cannot be altered — must be dropped and recreated.
+-- Safe to do: bill_fts uses content='bills', so all data is in the bills table.
+-- The rebuild re-indexes from the current bills rows (full_text = NULL for existing rows).
+
+ALTER TABLE bills ADD COLUMN full_text TEXT;
+
+DROP TABLE IF EXISTS bill_fts;
+
+CREATE VIRTUAL TABLE bill_fts
+USING fts5(
+  title,
+  summary,
+  full_text,
+  content='bills',
+  content_rowid='rowid'
+);
+
+INSERT INTO bill_fts(bill_fts) VALUES('rebuild');

--- a/apps/mcp-server/migrations/002-add-full-text-to-bills.sql
+++ b/apps/mcp-server/migrations/002-add-full-text-to-bills.sql
@@ -7,6 +7,14 @@
 -- FTS5 virtual tables cannot be altered — must be dropped and recreated.
 -- Safe to do: bill_fts uses content='bills', so all data is in the bills table.
 -- The rebuild re-indexes from the current bills rows (full_text = NULL for existing rows).
+--
+-- POST-DEPLOY VERIFICATION:
+--   The 'rebuild' insert below runs synchronously over the entire bills table and
+--   may hit D1's per-statement timeout on a populated production database. If it
+--   fails midway, bill_fts will be partially populated until the next writeBills()
+--   triggers another rebuild during cache refresh. After applying, verify:
+--     SELECT COUNT(*) FROM bill_fts;   -- should equal SELECT COUNT(*) FROM bills;
+--   If counts differ, kick a manual cache refresh or re-run the rebuild statement.
 
 ALTER TABLE bills ADD COLUMN full_text TEXT;
 

--- a/apps/mcp-server/src/cache/bills.test.ts
+++ b/apps/mcp-server/src/cache/bills.test.ts
@@ -501,6 +501,44 @@ describe('bills cache', () => {
     })
   })
 
+  // ── fullText storage and retrieval ──────────────────────────────────────
+
+  describe('fullText storage and retrieval', () => {
+    it('stores and returns fullText when bill has fullText', async () => {
+      await writeBills(env.DB, [makeBill({ fullText: 'Amends Section 53G-7-218 to require school cybersecurity plans' })])
+
+      const result = await getBillsBySponsor(env.DB, 'leg-001')
+      expect(result[0]?.fullText).toBe('Amends Section 53G-7-218 to require school cybersecurity plans')
+    })
+
+    it('returns fullText as undefined when bill has no fullText', async () => {
+      await writeBills(env.DB, [makeBill()])
+
+      const result = await getBillsBySponsor(env.DB, 'leg-001')
+      expect(result[0]?.fullText).toBeUndefined()
+    })
+
+    it('strips HTML tags from fullText before storing', async () => {
+      await writeBills(env.DB, [makeBill({ fullText: '<b>Amends</b> Section 53G-7-218 to <em>require</em> plans' })])
+
+      const result = await getBillsBySponsor(env.DB, 'leg-001')
+      expect(result[0]?.fullText).toBe('Amends Section 53G-7-218 to require plans')
+    })
+
+    it('FTS5 query matches content only in fullText — bill surfaces in search results', async () => {
+      await writeBills(env.DB, [makeBill({
+        id: 'HB0001',
+        title: 'School Funding Act',
+        summary: 'General school funding amendments',
+        fullText: 'uniqueprovisionterm that appears nowhere else in this bill',
+      })])
+
+      const result = await searchBills(env.DB, { query: 'uniqueprovisionterm' })
+      expect(result.total).toBe(1)
+      expect(result.bills[0]?.id).toBe('HB0001')
+    })
+  })
+
   // ── parseBillId (via searchBills) ────────────────────────────────────────
 
   describe('parseBillId (via searchBills)', () => {

--- a/apps/mcp-server/src/cache/bills.test.ts
+++ b/apps/mcp-server/src/cache/bills.test.ts
@@ -525,13 +525,50 @@ describe('bills cache', () => {
       expect(result[0]?.fullText).toBe('Amends Section 53G-7-218 to require plans')
     })
 
+    it('preserves non-tag angle brackets (inequalities, math) in fullText', async () => {
+      await writeBills(env.DB, [makeBill({ fullText: 'When A < B and C > D the rate applies' })])
+
+      const result = await getBillsBySponsor(env.DB, 'leg-001')
+      expect(result[0]?.fullText).toBe('When A < B and C > D the rate applies')
+    })
+
+    it('decodes common HTML entities in fullText before storing', async () => {
+      await writeBills(env.DB, [makeBill({ fullText: 'Amends &amp; revises school&#39;s policy &lt;5%&gt;' })])
+
+      const result = await getBillsBySponsor(env.DB, 'leg-001')
+      expect(result[0]?.fullText).toBe("Amends & revises school's policy <5%>")
+    })
+
+    it('returns fullText as undefined when API value is empty string', async () => {
+      await writeBills(env.DB, [makeBill({ fullText: '' })])
+
+      const result = await getBillsBySponsor(env.DB, 'leg-001')
+      expect(result[0]?.fullText).toBeUndefined()
+    })
+
+    it('returns fullText as undefined when API value is only HTML tags / whitespace', async () => {
+      await writeBills(env.DB, [makeBill({ fullText: '<br/><br/>   ' })])
+
+      const result = await getBillsBySponsor(env.DB, 'leg-001')
+      expect(result[0]?.fullText).toBeUndefined()
+    })
+
     it('FTS5 query matches content only in fullText — bill surfaces in search results', async () => {
-      await writeBills(env.DB, [makeBill({
-        id: 'HB0001',
-        title: 'School Funding Act',
-        summary: 'General school funding amendments',
-        fullText: 'uniqueprovisionterm that appears nowhere else in this bill',
-      })])
+      // Control bill: same title/summary as the target, but no fullText. Must NOT match,
+      // proving the match against `uniqueprovisionterm` came from `full_text` specifically.
+      await writeBills(env.DB, [
+        makeBill({
+          id: 'HB0001',
+          title: 'School Funding Act',
+          summary: 'General school funding amendments',
+          fullText: 'uniqueprovisionterm that appears nowhere else in this bill',
+        }),
+        makeBill({
+          id: 'HB0002',
+          title: 'School Funding Act',
+          summary: 'General school funding amendments',
+        }),
+      ])
 
       const result = await searchBills(env.DB, { query: 'uniqueprovisionterm' })
       expect(result.total).toBe(1)

--- a/apps/mcp-server/src/cache/bills.ts
+++ b/apps/mcp-server/src/cache/bills.ts
@@ -3,6 +3,7 @@
 // All functions accept db: D1Database as first parameter (dependency injection).
 // Column-to-type mapping (snake_case DB → camelCase Bill) is confined here.
 import type { Bill, SearchBillsParams, SearchBillsResult } from '@on-record/types'
+import { logger } from '../lib/logger.js'
 import { getActiveSession } from './sessions.js'
 
 // ── Row shape returned from D1 ───────────────────────────────────────────────
@@ -21,8 +22,27 @@ interface BillRow {
 
 // Strip HTML tags from highlightedProvisions before storage — applied defensively
 // since the Utah Legislature API does not document the field format.
+// Tag pattern requires `<` (with optional `/`) immediately followed by a letter, so
+// inequalities and stray angle brackets in plain text ("A < B and C > D") survive.
 function stripHtml(s: string): string {
-  return s.replace(/<[^>]+>/g, ' ').replace(/\s{2,}/g, ' ').trim()
+  const withoutTags = s.replace(/<\/?[a-zA-Z][^>]*>/g, ' ')
+  const decoded = withoutTags
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&')
+  return decoded.replace(/\s{2,}/g, ' ').trim()
+}
+
+// Normalize fullText for storage: undefined / empty / whitespace-only / pure-tag inputs all
+// collapse to null so absence semantics survive the round-trip through the DB.
+function normalizeFullText(value: string | undefined): string | null {
+  if (value === undefined) return null
+  const cleaned = stripHtml(value)
+  return cleaned === '' ? null : cleaned
 }
 
 function rowToBill(row: BillRow): Bill {
@@ -314,7 +334,7 @@ export async function writeBills(db: D1Database, bills: Bill[]): Promise<void> {
         bill.floorSponsorId ?? null,
         bill.voteResult ?? null,
         bill.voteDate ?? null,
-        bill.fullText !== undefined ? stripHtml(bill.fullText) : null,
+        normalizeFullText(bill.fullText),
         cachedAt,
       ),
   )
@@ -324,6 +344,13 @@ export async function writeBills(db: D1Database, bills: Bill[]): Promise<void> {
     await db.batch(stmts.slice(i, i + 100))
   }
 
-  // Rebuild FTS5 index after bulk inserts (must run after batch commits)
-  await db.prepare("INSERT INTO bill_fts(bill_fts) VALUES('rebuild')").run()
+  // Rebuild FTS5 index after bulk inserts (must run after batch commits).
+  // A failure here leaves bills rows committed but the FTS5 index stale; surface it
+  // for ops rather than rejecting the whole writeBills call (the rows are still useful
+  // for non-FTS reads, and the next refresh will re-attempt the rebuild).
+  try {
+    await db.prepare("INSERT INTO bill_fts(bill_fts) VALUES('rebuild')").run()
+  } catch (err) {
+    logger.error({ source: 'cache', err }, 'bill_fts rebuild failed after writeBills — index may be stale until next refresh')
+  }
 }

--- a/apps/mcp-server/src/cache/bills.ts
+++ b/apps/mcp-server/src/cache/bills.ts
@@ -16,6 +16,13 @@ interface BillRow {
   floor_sponsor_id: string | null
   vote_result: string | null
   vote_date: string | null
+  full_text: string | null
+}
+
+// Strip HTML tags from highlightedProvisions before storage — applied defensively
+// since the Utah Legislature API does not document the field format.
+function stripHtml(s: string): string {
+  return s.replace(/<[^>]+>/g, ' ').replace(/\s{2,}/g, ' ').trim()
 }
 
 function rowToBill(row: BillRow): Bill {
@@ -37,6 +44,9 @@ function rowToBill(row: BillRow): Bill {
   if (row.vote_date !== null) {
     bill.voteDate = row.vote_date
   }
+  if (row.full_text !== null) {
+    bill.fullText = row.full_text
+  }
   bill.billUrl = `https://le.utah.gov/~${row.session.slice(0, 4)}/bills/static/${row.id}.html`
   return bill
 }
@@ -50,7 +60,7 @@ function rowToBill(row: BillRow): Bill {
 export async function getBillsBySponsor(db: D1Database, sponsorId: string): Promise<Bill[]> {
   const result = await db
     .prepare(
-      'SELECT id, session, title, summary, status, sponsor_id, floor_sponsor_id, vote_result, vote_date FROM bills WHERE sponsor_id = ?',
+      'SELECT id, session, title, summary, status, sponsor_id, floor_sponsor_id, vote_result, vote_date, full_text FROM bills WHERE sponsor_id = ?',
     )
     .bind(sponsorId)
     .all<BillRow>()
@@ -66,7 +76,7 @@ export async function getBillsBySponsor(db: D1Database, sponsorId: string): Prom
 export async function getBillsBySession(db: D1Database, session: string): Promise<Bill[]> {
   const result = await db
     .prepare(
-      'SELECT id, session, title, summary, status, sponsor_id, floor_sponsor_id, vote_result, vote_date FROM bills WHERE session = ?',
+      'SELECT id, session, title, summary, status, sponsor_id, floor_sponsor_id, vote_result, vote_date, full_text FROM bills WHERE session = ?',
     )
     .bind(session)
     .all<BillRow>()
@@ -92,7 +102,7 @@ export async function searchBillsByTheme(
   try {
     const result = await db
       .prepare(
-        `SELECT b.id, b.session, b.title, b.summary, b.status, b.sponsor_id, b.floor_sponsor_id, b.vote_result, b.vote_date
+        `SELECT b.id, b.session, b.title, b.summary, b.status, b.sponsor_id, b.floor_sponsor_id, b.vote_result, b.vote_date, b.full_text
          FROM bill_fts
          JOIN bills b ON b.rowid = bill_fts.rowid
          WHERE bill_fts MATCH ?
@@ -213,7 +223,7 @@ export async function searchBills(
       ${nonFtsWhere}
     `
     const pageSql = `
-      SELECT b.id, b.session, b.title, b.summary, b.status, b.sponsor_id, b.floor_sponsor_id, b.vote_result, b.vote_date
+      SELECT b.id, b.session, b.title, b.summary, b.status, b.sponsor_id, b.floor_sponsor_id, b.vote_result, b.vote_date, b.full_text
       FROM bill_fts
       JOIN bills b ON b.rowid = bill_fts.rowid
       WHERE bill_fts MATCH ?
@@ -240,7 +250,7 @@ export async function searchBills(
       ${whereClause}
     `
     const pageSql = `
-      SELECT id, session, title, summary, status, sponsor_id, floor_sponsor_id, vote_result, vote_date
+      SELECT id, session, title, summary, status, sponsor_id, floor_sponsor_id, vote_result, vote_date, full_text
       FROM bills
       ${whereClause}
       ORDER BY session DESC, id ASC
@@ -291,8 +301,8 @@ export async function writeBills(db: D1Database, bills: Bill[]): Promise<void> {
     db
       .prepare(
         `INSERT OR REPLACE INTO bills
-          (id, session, title, summary, status, sponsor_id, floor_sponsor_id, vote_result, vote_date, cached_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+          (id, session, title, summary, status, sponsor_id, floor_sponsor_id, vote_result, vote_date, full_text, cached_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .bind(
         bill.id,
@@ -304,6 +314,7 @@ export async function writeBills(db: D1Database, bills: Bill[]): Promise<void> {
         bill.floorSponsorId ?? null,
         bill.voteResult ?? null,
         bill.voteDate ?? null,
+        bill.fullText !== undefined ? stripHtml(bill.fullText) : null,
         cachedAt,
       ),
   )

--- a/apps/mcp-server/src/cache/refresh.test.ts
+++ b/apps/mcp-server/src/cache/refresh.test.ts
@@ -209,6 +209,32 @@ describe('warmUpBillsCache', () => {
     expect(sessions).toEqual(['2026GS'])
   })
 
+  it('propagates fullText from BillDetail into cached bills row', async () => {
+    const detail: BillDetail = {
+      id: 'HB0001',
+      session: '2026GS',
+      title: 'Test Bill',
+      summary: 'A test bill for unit testing',
+      status: 'enrolled',
+      sponsorId: 'leg-001',
+      fullText: 'Amends Section 53G-7-218 to require school cybersecurity plans',
+    }
+    const provider: LegislatureDataProvider = {
+      getLegislatorsByDistrict: vi.fn<() => Promise<Legislator[]>>().mockResolvedValue([]),
+      getBillStubsForSession: vi.fn<() => Promise<string[]>>().mockResolvedValue(['HB0001']),
+      getBillsBySession: vi.fn<() => Promise<Bill[]>>().mockResolvedValue([]),
+      getBillDetail: vi.fn<(billId: string, session: string) => Promise<BillDetail>>().mockResolvedValue(detail),
+    }
+
+    await warmUpBillsCache(env.DB, provider)
+
+    const row = await env.DB
+      .prepare('SELECT full_text FROM bills WHERE id = ?')
+      .bind('HB0001')
+      .first<{ full_text: string | null }>()
+    expect(row?.full_text).toBe('Amends Section 53G-7-218 to require school cybersecurity plans')
+  })
+
   it('logs error and skips session when getBillStubsForSession throws — does not propagate', async () => {
     const provider: LegislatureDataProvider = {
       getLegislatorsByDistrict: vi.fn<() => Promise<Legislator[]>>().mockResolvedValue([]),

--- a/apps/mcp-server/src/cache/refresh.ts
+++ b/apps/mcp-server/src/cache/refresh.ts
@@ -202,6 +202,7 @@ export async function warmUpBillsCache(
         ...(detail.floorSponsorId !== undefined && { floorSponsorId: detail.floorSponsorId }),
         ...(detail.voteResult !== undefined && { voteResult: detail.voteResult }),
         ...(detail.voteDate !== undefined && { voteDate: detail.voteDate }),
+        ...(detail.fullText !== undefined && { fullText: detail.fullText }),
       })))
     }
 

--- a/apps/mcp-server/src/cache/schema.ts
+++ b/apps/mcp-server/src/cache/schema.ts
@@ -27,6 +27,7 @@ CREATE TABLE IF NOT EXISTS bills (
   floor_sponsor_id TEXT,
   vote_result      TEXT,
   vote_date        TEXT,
+  full_text        TEXT,
   cached_at        TEXT    NOT NULL,
   PRIMARY KEY (id, session)
 );
@@ -35,6 +36,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS bill_fts
 USING fts5(
   title,
   summary,
+  full_text,
   content='bills',
   content_rowid='rowid'
 );

--- a/apps/mcp-server/src/providers/utah-legislature.test.ts
+++ b/apps/mcp-server/src/providers/utah-legislature.test.ts
@@ -492,6 +492,32 @@ describe('UtahLegislatureProvider', () => {
       await vi.runAllTimersAsync()
       await rejectionPromise
     })
+
+    it('includes fullText on returned Bill when API provides highlightedProvisions', async () => {
+      fetchMock
+        .mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify([{ number: 'HB0001', trackingID: 'TUBFCRPIYI' }]) })
+        .mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify(mockBillDetailResponse) })
+
+      const promise = provider.getBillsBySession('2026GS')
+      await vi.runAllTimersAsync()
+      const result = await promise
+
+      expect(result).toHaveLength(1)
+      expect(result[0]?.fullText).toBe('This bill amends weighted pupil unit provisions...')
+    })
+
+    it('omits fullText (property absent) when API lacks highlightedProvisions', async () => {
+      fetchMock
+        .mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify([{ number: 'HB0002', trackingID: 'BKSTYLLAEC' }]) })
+        .mockResolvedValueOnce({ ok: true, text: async () => JSON.stringify(mockBillDetail2Response) })
+
+      const promise = provider.getBillsBySession('2026GS')
+      await vi.runAllTimersAsync()
+      const result = await promise
+
+      expect(result).toHaveLength(1)
+      expect('fullText' in (result[0] ?? {})).toBe(false)
+    })
   })
 
   describe('getBillDetail', () => {

--- a/apps/mcp-server/src/providers/utah-legislature.ts
+++ b/apps/mcp-server/src/providers/utah-legislature.ts
@@ -188,6 +188,7 @@ export class UtahLegislatureProvider implements LegislatureDataProvider {
             ...(detail.floorSponsorId !== undefined && { floorSponsorId: detail.floorSponsorId }),
             ...(detail.voteResult !== undefined && { voteResult: detail.voteResult }),
             ...(detail.voteDate !== undefined && { voteDate: detail.voteDate }),
+            ...(detail.fullText !== undefined && { fullText: detail.fullText }),
           })
         } else {
           logger.error(

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -29,12 +29,12 @@ export interface Bill {
   voteResult?: string
   voteDate?: string // ISO 8601 date string: "2024-03-04"
   billUrl?: string // computed from id + session; not stored in DB
+  fullText?: string // highlightedProvisions from Utah Legislature API; stored in DB
 }
 
 // BillDetail — used by LegislatureDataProvider.getBillDetail() (Story 2.2)
 // Full shape finalized in Story 2.2 when the provider interface is implemented.
 export interface BillDetail extends Bill {
-  fullText?: string
   subjects?: string[]
 }
 


### PR DESCRIPTION
## Summary

- Wires the `highlightedProvisions` field from the Utah Legislature API (already fetched on every cache refresh but previously discarded) into the `bills` D1 cache as `full_text TEXT`
- Adds `fullText?: string` to the `Bill` type and includes it in `search_bills` responses automatically — no tool layer changes needed
- Extends the `bill_fts` FTS5 virtual table with `full_text` as a third indexed column, improving keyword search quality (bills matching a query in their specific statutory change description now surface)
- HTML stripping applied defensively at write time (`stripHtml()` regex helper) since the API docs don't specify the field format

## Changes

- **`packages/types/index.ts`**: `fullText?: string` moved from `BillDetail` to `Bill` (inherited by `BillDetail`)
- **`migrations/001-initial-schema.sql`** + **`cache/schema.ts`**: `full_text TEXT` added to `bills` table; `bill_fts` FTS5 updated with `full_text` column
- **`migrations/002-add-full-text-to-bills.sql`** *(new)*: D1 production migration — `ALTER TABLE bills ADD COLUMN full_text TEXT` + DROP/CREATE `bill_fts` + REBUILD
- **`cache/bills.ts`**: `BillRow`, `rowToBill`, `writeBills`, all SELECT queries updated; `stripHtml()` helper added
- **`providers/utah-legislature.ts`**: `getBillsBySession()` now spreads `fullText` from `BillDetail` into the cached `Bill`

## Test plan

- [ ] All 210 tests pass (`pnpm --filter mcp-server test`)
- [ ] 6 new tests added: fullText round-trip, null→undefined mapping, HTML stripping at write time, FTS5 search matching on `full_text`, `getBillsBySession` fullText propagation (present and absent cases)
- [ ] `migrations/002-add-full-text-to-bills.sql` should be applied to production D1: `wrangler d1 migrations apply on-record-cache`

This is story 4.10 (E5-z from the 2026-04-18 ChatGPT Apps technical research).

Closes #32

https://claude.ai/code/session_01RVhJ8NQXs5c4CHdP6XFQdc

---
_Generated by [Claude Code](https://claude.ai/code/session_01RVhJ8NQXs5c4CHdP6XFQdc)_