### PR TITLE
ci: add D1 migration workflow

### DIFF
--- a/.github/workflows/d1-migrate.yml
+++ b/.github/workflows/d1-migrate.yml
@@ -1,0 +1,42 @@
+name: D1 Migrate
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/mcp-server/migrations/**'
+
+env:
+  NODE_VERSION: '20'
+  PNPM_VERSION: '10'
+
+jobs:
+  migrate:
+    name: Run D1 Migrations
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run D1 migrations
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: apps/mcp-server
+          command: d1 migrations apply on-record-cache --remote

--- a/apps/mcp-server/migrations/001-initial-schema.sql
+++ b/apps/mcp-server/migrations/001-initial-schema.sql
@@ -1,6 +1,6 @@
 -- migrations/001-initial-schema.sql
 -- Clean schema for D1 (no migration logic — fresh install).
--- Applied via: wrangler d1 migrations apply on-record-cache --local
+-- Applied via: wrangler d1 migrations apply on-record-cache --remote
 
 CREATE TABLE IF NOT EXISTS legislators (
   id          TEXT    PRIMARY KEY,


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow that triggers on pushes to `main` when files under `apps/mcp-server/migrations/` change
- Runs `wrangler d1 migrations apply on-record-cache --remote` using existing `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID` secrets

## Test plan
- [ ] Merge a PR that includes a new migration file and verify the workflow runs and applies successfully
- [ ] Merge a PR with no migration changes and verify the workflow does not trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)